### PR TITLE
 Fix bug with #getOriginalCaretPos() on Safari

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "textarea-helper",
   "main": "textarea-helper.js",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "homepage": "https://github.com/Codecademy/textarea-helper",
   "authors": [
     "Amjad Masad <amjad.masad@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textarea-helper",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "**textareaHelper** is a small library that mirrors a textarea's content onto a <div> to add functionality to query the height and the carent position",
   "main": "textarea-helper.js",
   "repository": {

--- a/textarea-helper.jquery.json
+++ b/textarea-helper.jquery.json
@@ -1,6 +1,6 @@
 {
   "name": "textarea-helper",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "title": "Textarea Helper plugin",
   "author": {
     "name": "Amjad Masad",

--- a/textarea-helper.js
+++ b/textarea-helper.js
@@ -82,8 +82,8 @@
     // Adapted from http://stackoverflow.com/questions/263743/how-to-get-caret-position-in-textarea
     this.getOriginalCaretPos = function () {
       var text = this.$text[0];
-      if (text.selectionStart) {
-        return text.selectionStart;
+      if (typeof text.selectionStart === 'number') {
+        return text.value.length;
       } else if (document.selection) {
         text.focus();
         var r = document.selection.createRange();


### PR DESCRIPTION
I just have found this addition in another branch and maybe it needs to be merged?